### PR TITLE
Remove mention to readligo

### DIFF
--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -365,10 +365,7 @@
     "id": "1irX8-UnvvXd"
    },
    "source": [
-    "Notes: There are alternative ways to access the GWOSC data. \n",
-    "\n",
-    "* [`readligo`](https://losc.ligo.org/s/sample_code/readligo.py) is a light-weight Python module that returns the time series into a Numpy array.\n",
-    "* The [PyCBC](http://github.com/ligo-cbc/pycbc) package has the `pycbc.frame.query_and_read_frame` and `pycbc.frame.read_frame` methods. We use [PyCBC](http://github.com/ligo-cbc/pycbc) in Tutorial 2.1, 2.2 and 2.3. "
+    "Note: There are alternative ways to access GWOSC data. The [PyCBC](http://github.com/ligo-cbc/pycbc) package has the `pycbc.frame.query_and_read_frame` and `pycbc.frame.read_frame` methods that we will learn in tutorials 2.1 to 2.3."
    ]
   },
   {


### PR DESCRIPTION
- Removes mention to readligo as an alternative to fetch data from gwosc
- Re-words sentence about pyCBC and its methods to get data

There are no other mentions to readligo in the repo besides this one.

This closes #1 
