### PR TITLE
Updated gwosc URL

### DIFF
--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "#### Tutorial 1.1: Discovering open data from GW observatories\n",
     "\n",
-    "This notebook describes how to discover what data are available from the [Gravitational-Wave Open Science Center (GWOSC)](https://www.gw-openscience.org).\n",
+    "This notebook describes how to discover what data are available from the [Gravitational-Wave Open Science Center (GWOSC)](https://gwosc.org).\n",
     "    \n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw-2024/blob/main/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb)"
    ]
@@ -82,7 +82,7 @@
     "The module `gwosc.datasets` provides tools for searching for datasets, including events, catalogs and full run strain data releases.\n",
     "\n",
     "\n",
-    "For example, we can search for events in the [GWTC-1 catalog](https://www.gw-openscience.org/eventapi/html/GWTC-1-confident/), the catalog of all events from the O1 and O2 observing runs. A list of available catalogs can be seen in the [Event Portal](https://gw-openscience.org/eventapi)"
+    "For example, we can search for events in the [GWTC-1 catalog](https://gwosc.org/eventapi/html/GWTC-1-confident/), the catalog of all events from the O1 and O2 observing runs. A list of available catalogs can be seen in the [Event Portal](https://gwosc.org/eventapi)"
    ]
   },
   {
@@ -247,7 +247,7 @@
     "id": "hKvQhYAOQ8OG"
    },
    "source": [
-    "<div class=\"alert alert-info\">All of these times are returned in the GPS time system, which counts the number of seconds that have elapsed since the start of the GPS epoch at midnight (00:00) on January 6th 1980. GWOSC provides a <a href=\"https://www.gw-openscience.org/gps/\">GPS time converter</a> you can use to translate into datetime, or you can use <a href=\"https://gwpy.github.io/docs/stable/time/\"><code>gwpy.time</code></a>.</div>"
+    "<div class=\"alert alert-info\">All of these times are returned in the GPS time system, which counts the number of seconds that have elapsed since the start of the GPS epoch at midnight (00:00) on January 6th 1980. GWOSC provides a <a href=\"https://gwosc.org/gps/\">GPS time converter</a> you can use to translate into datetime, or you can use <a href=\"https://gwpy.github.io/docs/stable/time/\"><code>gwpy.time</code></a>.</div>"
    ]
   },
   {
@@ -444,7 +444,7 @@
    "metadata": {},
    "source": [
     "##  Query filtered by merger parameters\n",
-    "The `query_events` module of `gwosc.datasets` allows to get a list of events filtered by some parameters, similar to what is done by the `Query` function of the [event portal](https://www.gw-openscience.org/eventapi/html/query/). A list of available parameters can be found [here](https://gwosc.readthedocs.io/en/stable/reference/gwosc.datasets.query_events.html) or using `query_events?`. \n",
+    "The `query_events` module of `gwosc.datasets` allows to get a list of events filtered by some parameters, similar to what is done by the `Query` function of the [event portal](https://gwosc.org/eventapi/html/query/). A list of available parameters can be found [here](https://gwosc.readthedocs.io/en/stable/reference/gwosc.datasets.query_events.html) or using `query_events?`. \n",
     "\n",
     "Let's see how to use this module to find which events have been detected with a network signal to noise ratio (SNR) between 25 and 30:"
    ]

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -139,10 +139,10 @@
    "source": [
     "#### Finding open data\n",
     "\n",
-    "We have seen already that the `gwosc` module can be used to query for what data are available on [GWOSC](https://www.gw-openscience.org/data/).\n",
+    "We have seen already that the `gwosc` module can be used to query for what data are available on [GWOSC](https://gwosc.org/data/).\n",
     "The next thing to do is to actually read some open data. Let's try to get some for GW190412, the first detection of a gravitational-wave signal from a significantly unequal-mass BBH (binary black hole system).\n",
     "\n",
-    "We can use the [TimeSeries.fetch_open_data](https://gwpy.github.io/docs/stable/api/gwpy.timeseries.TimeSeries/#gwpy.timeseries.TimeSeries.fetch_open_data) method to download data directly from https://www.gw-openscience.org, but we need to know the GPS times.\n",
+    "We can use the [TimeSeries.fetch_open_data](https://gwpy.github.io/docs/stable/api/gwpy.timeseries.TimeSeries/#gwpy.timeseries.TimeSeries.fetch_open_data) method to download data directly from https://gwosc.org, but we need to know the GPS times.\n",
     "We can query for the GPS time of an event as follows:"
    ]
   },
@@ -647,7 +647,7 @@
     "- ~500 Hz\n",
     "- ~1000 Hz\n",
     "\n",
-    "The [O3 spectral lines](https://www.gw-openscience.org/O3/o3aspeclines/) page on GWOSC describes a number of these spectral features for O3, with some of them being forced upon us, and some being deliberately introduced to help with interferometer control.\n",
+    "The [O3 spectral lines](https://gwosc.org/O3/o3aspeclines/) page on GWOSC describes a number of these spectral features for O3, with some of them being forced upon us, and some being deliberately introduced to help with interferometer control.\n",
     "\n",
     "Loading more data allows for more FFTs to be averaged during the ASD estimation, meaning random variations get averaged out, and we can see more detail:"
    ]

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -397,7 +397,7 @@
    "source": [
     "### Exercise\n",
     "\n",
-    "Generate and plot the waveform associated to the binary neutron star merger GW170817. Look up the [GWTC-1](https://www.gw-openscience.org/GWTC-1/) catalog page to obtain the estimated parameters for this source.\n",
+    "Generate and plot the waveform associated to the binary neutron star merger GW170817. Look up the [GWTC-1](https://gwosc.org/GWTC-1/) catalog page to obtain the estimated parameters for this source.\n",
     "\n",
     "How much time does the signal last using a lower frequency of 30 Hz?"
    ]

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -103,7 +103,7 @@
     "The purpose of preconditioning data is to reduce the dynamic range of the data and to suppress low frequency behavior that can introduce numerical artefacts.\n",
     "We may also wish to reduce the sample rate of the data if high frequency content is not important.\n",
     "\n",
-    "PyCBC contains an interface to the [GWOSC catalog](https://www.gw-openscience.org/eventapi/), so you can easily access the data and parameters of the published gravitational-wave signals."
+    "PyCBC contains an interface to the [GWOSC catalog](https://gwosc.org/eventapi/), so you can easily access the data and parameters of the published gravitational-wave signals."
    ]
   },
   {

--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -150,7 +150,7 @@
     "\n",
     "In this notebook, we'll analyse GW150914. Our first task is to obtain some data!\n",
     "\n",
-    "We need to know the trigger time. This can be found on the [GWOSC page](https://www.gw-openscience.org/events/GW150914/), here we define it as a variable"
+    "We need to know the trigger time. This can be found on the [GWOSC page](https://gwosc.org/events/GW150914/), here we define it as a variable"
    ]
   },
   {
@@ -1317,7 +1317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also plot lines indicating specific points. Here, we add the values recorded on [GWOSC](https://www.gw-openscience.org/events/GW150914/). Notably, these fall outside the bulk of the posterior uncertainty here. This is because we limited our prior to a non-spinning analysis - if instead we ran the full analysis these agree nicely."
+    "You can also plot lines indicating specific points. Here, we add the values recorded on [GWOSC](https://gwosc.org/events/GW150914/). Notably, these fall outside the bulk of the posterior uncertainty here. This is because we limited our prior to a non-spinning analysis - if instead we ran the full analysis these agree nicely."
    ]
   },
   {

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -31,7 +31,7 @@
     "- The formalism of the LALInference package is described in the following article: \n",
     "[Phys. Rev. D 91, 042003 (2015)](https://arxiv.org/abs/1409.7215)\n",
     "- A lecture of GW parameter estimation with Bayesian inference: [Recording of GWOSC ODW #2](https://www.youtube.com/watch?v=_NaAKeVJe1s&t=1s)\n",
-    "- All the GWOSC open data workshops lectures: [Link to GWOSC ODW](https://www.gw-openscience.org/workshops/)\n",
+    "- All the GWOSC open data workshops lectures: [Link to GWOSC ODW](https://gwosc.org/workshops/)\n",
     "\n",
     "#### Acknowledgements\n",
     "This tutorial is created by Leïla Haegel (leila.haegel@ligo.org), based on utilitary software designed by the LVK collaboration members. A special thanks is due to Charlie Hoy and Marc Arène for their assistance in understanding `PESummary` and `LALInference`.\n",
@@ -174,9 +174,9 @@
    "source": [
     "## Getting the data: GW190828_063405\n",
     "\n",
-    "In this notebook, we analyse GW190828_063405. Information on the event can be found on the [GWOSC page](https://www.gw-openscience.org/eventapi/html/GWTC-2/GW190828_063405/). \n",
+    "In this notebook, we analyse GW190828_063405. Information on the event can be found on the [GWOSC page](https://gwosc.org/eventapi/html/GWTC-2/GW190828_063405/). \n",
     "\n",
-    "The notebook can be adapted to analyse any other event from the [GWTC-2](https://www.gw-openscience.org/GWTC-2/), [2.1](https://www.gw-openscience.org/GWTC-2.1/) & [3](https://www.gw-openscience.org/GWTC-3/) catalogs. \n",
+    "The notebook can be adapted to analyse any other event from the [GWTC-2](https://gwosc.org/GWTC-2/), [2.1](https://gwosc.org/GWTC-2.1/) & [3](https://gwosc.org/GWTC-3/) catalogs. \n",
     "\n"
    ]
   },
@@ -775,7 +775,7 @@
     "- the waveform approximant `approx`\n",
     "- the reference frequency `fref` (optional)\n",
     "\n",
-    "The trigger time `trigtime` that must be copied from the [GWOSC page](https://www.gw-openscience.org/eventapi/html/GWTC-2/GW190828_063405/). "
+    "The trigger time `trigtime` that must be copied from the [GWOSC page](https://gwosc.org/eventapi/html/GWTC-2/GW190828_063405/). "
    ]
   },
   {


### PR DESCRIPTION
Changed the old gwosc url (https://gw-openscience.org) references to the new url (https://gwosc.org)

This closes #18.
