### PR TITLE
Add unit test for checking links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,78 @@
+name: Check Links In Pull Requests
+
+on:
+  pull_request:
+    branches:
+      - main
+    # Limit the check to certain file types
+    paths:
+      - '**/*.md'
+      - '**/*.ipynb'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Check out base branch
+        run: git checkout ${{github.event.pull_request.base.ref}}
+
+      - name: Dump all links from ${{github.event.pull_request.base.ref}}
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: |
+            --dump
+            --include-fragments
+            './**/*.ipynb' './**/*.md'
+          output: ./existing-links.txt
+        continue-on-error: true # Don't fail if base branch check has issues
+
+      - name: Stash untracked files
+        run: git stash push --include-untracked
+
+      - name: Check out feature branch
+        run: git checkout ${{ github.head_ref }}
+
+      - name: Apply stashed changes
+        run: git stash pop || true
+
+      - name: Update ignore file
+        run: |
+          if [ -f "existing-links.txt" ]; then
+            cat existing-links.txt >> .lycheeignore
+          fi
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: |
+            --no-progress
+            --include-fragments
+            './**/*.ipynb' './**/*.md'
+
+      - name: Provide helpful failure message
+        if: failure()
+        run: |
+          echo "::error::Link check failed! Please review the broken links reported above."
+          echo ""
+          echo "If certain links are valid but fail due to:"
+          echo "- CAPTCHA challenges"
+          echo "- IP blocking"
+          echo "- Authentication requirements"
+          echo "- Rate limiting"
+          echo ""
+          echo "Consider adding them to .lycheeignore to bypass future checks."
+          echo "Format: Add one URL pattern per line"
+          exit 1

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,13 +1,12 @@
 name: Check Links In Pull Requests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
-    # Limit the check to certain file types
-    paths:
-      - '**/*.md'
-      - '**/*.ipynb'
   workflow_dispatch:
 
 concurrency:
@@ -19,47 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-
-      - name: Check out base branch
-        run: git checkout ${{github.event.pull_request.base.ref}}
-
-      - name: Dump all links from ${{github.event.pull_request.base.ref}}
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: |
-            --dump
-            --include-fragments
-            './**/*.ipynb' './**/*.md'
-          output: ./existing-links.txt
-        continue-on-error: true # Don't fail if base branch check has issues
-
-      - name: Stash untracked files
-        run: git stash push --include-untracked
-
-      - name: Check out feature branch
-        run: git checkout ${{ github.head_ref }}
-
-      - name: Apply stashed changes
-        run: git stash pop || true
-
-      - name: Update ignore file
-        run: |
-          if [ -f "existing-links.txt" ]; then
-            cat existing-links.txt >> .lycheeignore
-          fi
-
+      - uses: actions/checkout@v4
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
           args: |
             --no-progress
             --include-fragments
+            -E
+            --require-https
             './**/*.ipynb' './**/*.md'
 
       - name: Provide helpful failure message

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -21,3 +21,9 @@ https://dcc.ligo.org/LIGO-P1800370/public/%7Blabel%7D_GWTC-1.hdf5
 
 # Exclude all file-links. Workaround until https://github.com/lycheeverse/lychee/issues/1646 is resolved
 file://
+
+# These URL return 403 under lychee but work under a browser so we ignore them for now
+https://journals.aps.org/prx/pdf/10.1103/PhysRevX.9.011001
+https://journals.aps.org/prd/abstract/10.1103/PhysRevD.93.044006
+https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.119.161101
+https://doi.org/10.1088/0264-9381/21/20/024

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,23 @@
+# Issues with links in Jupyter Notebook files.
+# Remove once https://github.com/lycheeverse/lychee/issues/1659 is resolved.
+https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz/n
+https://dcc.ligo.org/public/0157/P1800370/005/GW150914_GWTC-1.hdf5/n
+https://raw.githubusercontent.com/gw-odw/odw/main/Tutorials/Day_3/toy_model.csv/n
+https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T2_1.gwf/n
+https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T2_2.gwf/n
+https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T2_0.gwf/n
+https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T3_0.gwf/n
+https://lscsoft.docs.ligo.org/bilby/examples.html/n
+http://pycbc.org/pycbc/latest/html/noise.html/n
+https://raw.githubusercontent.com/gw-odw/odw/main/Tutorials/Day_3/toy_model.csv/n
+https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz/
+
+# Some python cells use format string to forge URL.
+# The `{` (resp. `}`) there get translated to `%7B`(resp. `%7D`).
+# This is hard to fix with lychee since it can't understand placeholders.
+# So this is another valid exclude.
+https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/%7B%7D/
+https://dcc.ligo.org/LIGO-P1800370/public/%7Blabel%7D_GWTC-1.hdf5
+
+# Exclude all file-links. Workaround until https://github.com/lycheeverse/lychee/issues/1646 is resolved
+file://


### PR DESCRIPTION
This uses [lychee GH action](https://lychee.cli.rs/github_action_recipes/pull-requests/) to check that new links introduced in a PR are all working. It may catch malformed URLs, or dead/wrong URLs.

~~It will compare the ones found in the base branch against the feature branch. It will not report broken links on base (we could potentially change that.)~~

It's only triggered where a `*.md` or `*.ipynb` file is modified, so (ironically) it will not run for this PR.
