### PR TITLE
Update broken links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -28,6 +28,11 @@ https://journals.aps.org/prd/abstract/10.1103/PhysRevD.93.044006
 https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.119.161101
 https://doi.org/10.1088/0264-9381/21/20/024
 
+# This URL is the portal toward Thinkific courses
+# It returns 403 from GitHub actions
+# We believe it's because Thinkific (which eventually answers) blocks GitHub IPs
+https://learn.gwosc.org
+
 # The GWOSC server returns http URLs
 # We ignore them for now
 http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126259447-32.hdf5

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -27,3 +27,10 @@ https://journals.aps.org/prx/pdf/10.1103/PhysRevX.9.011001
 https://journals.aps.org/prd/abstract/10.1103/PhysRevD.93.044006
 https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.119.161101
 https://doi.org/10.1088/0264-9381/21/20/024
+
+# The GWOSC server returns http URLs
+# We ignore them for now
+http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126259447-32.hdf5
+http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126257415-4096.hdf5
+http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126259447-32.hdf5
+http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126257415-4096.hdf5

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,7 +8,7 @@ https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T2_2.gwf/n
 https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T2_0.gwf/n
 https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T3_0.gwf/n
 https://lscsoft.docs.ligo.org/bilby/examples.html/n
-http://pycbc.org/pycbc/latest/html/noise.html/n
+https://pycbc.org/pycbc/latest/html/noise.html/n
 https://raw.githubusercontent.com/gw-odw/odw/main/Tutorials/Day_3/toy_model.csv/n
 https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz/
 

--- a/Challenge/README.md
+++ b/Challenge/README.md
@@ -11,7 +11,7 @@ Data files may be downloaded from [DCC G2300818](https://dcc.ligo.org/LIGO-G2300
 * [challenge3.gwf](https://dcc.ligo.org/public/0187/G2300818/001/challenge3.gwf)
 * [challenge3_2048hz.gwf](https://dcc.ligo.org/public/0187/G2300818/001/challenge3_2048hz.gwf)   <-- Downsampled version of Challenge 3 file
 
-Workshop participants may [submit solutions via thinkific](https://gw-odw.thinkific.com) as individuals or in teams of up to 3 people.
+Workshop participants may [submit solutions via thinkific](https://learn.gwosc.org) as individuals or in teams of up to 3 people.
 Check for the deadline date on the Thinkific website.
 
 Challenges are ordered by difficulty. Entries will be rewarded a number of

--- a/Tutorials/Day_1/README.md
+++ b/Tutorials/Day_1/README.md
@@ -8,7 +8,7 @@ Click a badge below to run the notebooks
 
 ## Challenge Questions
 
-* Answer associated challenge questions in the [online course](https://gw-odw.thinkific.com)
+* Answer associated challenge questions in the [online course](https://learn.gwosc.org)
 
 ## More documentation
 

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -114,7 +114,7 @@
     "[GWpy](https://gwpy.github.io/docs/stable/index.html) is heavily object-oriented, meaning almost all of the code you run using GWpy is based around an object of some type, e.g. `TimeSeries`.\n",
     "Most of the methods (functions) we will use are attached to an object, rather than standing alone, meaning you should have a pretty good idea of what sort of data you are dealing with (without having to read the documentation!).\n",
     "\n",
-    "For a quick overview of object-oriented programming in Python, see [this blog post by Jeff Knupp](https://jeffknupp.com/blog/2014/06/18/improve-your-python-python-classes-and-object-oriented-programming/)."
+    "For a quick overview of object-oriented programming in Python, see [this blog post by Jeff Knupp](https://medium.com/hackernoon/improve-your-python-python-classes-and-object-oriented-programming-d09ff461168d)."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -359,7 +359,7 @@
     "id": "1irX8-UnvvXd"
    },
    "source": [
-    "Note: There are alternative ways to access GWOSC data. The [PyCBC](http://github.com/ligo-cbc/pycbc) package has the `pycbc.frame.query_and_read_frame` and `pycbc.frame.read_frame` methods that we will learn in tutorials 2.1 to 2.3."
+    "Note: There are alternative ways to access GWOSC data. The [PyCBC](https://github.com/ligo-cbc/pycbc) package has the `pycbc.frame.query_and_read_frame` and `pycbc.frame.read_frame` methods that we will learn in tutorials 2.1 to 2.3."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "This tutorial shows how to numerically obtain the gravitational waveform radiated during a compact binary coalescence, assuming the basic parameters of the binary are known.\n",
     "\n",
-    "We will be using the [PyCBC](http://github.com/ligo-cbc/pycbc) library, which provides an easy-to-use Python interface to obtain such waveforms. PyCBC can more generally be used to analyze or simulate gravitational-wave data, find or simulate astrophysical signals from compact binary mergers, and study their parameters. It is one of the tools routinely used by groups within and outside of the LIGO and Virgo collaborations. Additional [examples](http://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](http://pycbc.org/pycbc/latest/html/py-modindex.html).\n",
+    "We will be using the [PyCBC](https://github.com/ligo-cbc/pycbc) library, which provides an easy-to-use Python interface to obtain such waveforms. PyCBC can more generally be used to analyze or simulate gravitational-wave data, find or simulate astrophysical signals from compact binary mergers, and study their parameters. It is one of the tools routinely used by groups within and outside of the LIGO and Virgo collaborations. Additional [examples](http://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](http://pycbc.org/pycbc/latest/html/py-modindex.html).\n",
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw/blob/main/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb)"
    ]

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "This tutorial shows how to numerically obtain the gravitational waveform radiated during a compact binary coalescence, assuming the basic parameters of the binary are known.\n",
     "\n",
-    "We will be using the [PyCBC](https://github.com/ligo-cbc/pycbc) library, which provides an easy-to-use Python interface to obtain such waveforms. PyCBC can more generally be used to analyze or simulate gravitational-wave data, find or simulate astrophysical signals from compact binary mergers, and study their parameters. It is one of the tools routinely used by groups within and outside of the LIGO and Virgo collaborations. Additional [examples](http://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](http://pycbc.org/pycbc/latest/html/py-modindex.html).\n",
+    "We will be using the [PyCBC](https://github.com/ligo-cbc/pycbc) library, which provides an easy-to-use Python interface to obtain such waveforms. PyCBC can more generally be used to analyze or simulate gravitational-wave data, find or simulate astrophysical signals from compact binary mergers, and study their parameters. It is one of the tools routinely used by groups within and outside of the LIGO and Virgo collaborations. Additional [examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](https://pycbc.org/pycbc/latest/html/py-modindex.html).\n",
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw/blob/main/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb)"
    ]
@@ -113,9 +113,9 @@
    "source": [
     "### Generate your first waveform!\n",
     "\n",
-    "Here we'll generate the gravitational waveform using one of the available waveform approximants. The waveform can be generated as a time series using [`get_td_waveform()`](http://pycbc.org/pycbc/latest/html/pycbc.waveform.html#pycbc.waveform.waveform.get_td_waveform) or in the frequency domain using [`get_fd_waveform()`](http://pycbc.org/pycbc/latest/html/pycbc.waveform.html#pycbc.waveform.waveform.get_fd_waveform). \n",
+    "Here we'll generate the gravitational waveform using one of the available waveform approximants. The waveform can be generated as a time series using [`get_td_waveform()`](https://pycbc.org/pycbc/latest/html/pycbc.waveform.html#pycbc.waveform.waveform.get_td_waveform) or in the frequency domain using [`get_fd_waveform()`](https://pycbc.org/pycbc/latest/html/pycbc.waveform.html#pycbc.waveform.waveform.get_fd_waveform). \n",
     "\n",
-    "There are some additional examples using this interface [here](http://pycbc.org/pycbc/latest/html/waveform.html). The key parameters are the masses of the binary (given in solar masses), the time between samples (in seconds), the starting gravitational-wave frequency (Hz) and the name of the approximant we'd like to use. A variety of approximants are available that include different physical effects.\n",
+    "There are some additional examples using this interface [here](https://pycbc.org/pycbc/latest/html/waveform.html). The key parameters are the masses of the binary (given in solar masses), the time between samples (in seconds), the starting gravitational-wave frequency (Hz) and the name of the approximant we'd like to use. A variety of approximants are available that include different physical effects.\n",
     "\n",
     "In this example, we've chosen to use the 'IMRPhenomD' approximant. This is an implementation of the model introduced [in this paper](https://arxiv.org/pdf/1508.07253.pdf). There are many other models available, with different methodologies employed and physical effects modelled. A full review of the models is outside of the scope of this tutorial."
    ]

--- a/Tutorials/Day_2/README.md
+++ b/Tutorials/Day_2/README.md
@@ -9,7 +9,7 @@ Click a badge below to run the notebooks
 
 ### Challenge Questions
 
-* Answer associated challenge questions in the [online course](https://gw-odw.thinkific.com)
+* Answer associated challenge questions in the [online course](https://learn.gwosc.org)
 
 ### More documentation
 

--- a/Tutorials/Day_2/README.md
+++ b/Tutorials/Day_2/README.md
@@ -14,5 +14,5 @@ Click a badge below to run the notebooks
 ### More documentation
 
 * [bilby documentation](https://lscsoft.docs.ligo.org/bilby/index.html)
-* [PyCBC documentation](http://pycbc.org/pycbc/latest/html/)
+* [PyCBC documentation](https://pycbc.org/pycbc/latest/html/)
 

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "## Tutorial 2.1 PyCBC Tutorial, An introduction to matched-filtering\n",
     "\n",
-    "We will be using the [PyCBC](http://github.com/ligo-cbc/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
+    "We will be using the [PyCBC](https://github.com/ligo-cbc/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
     "\n",
     "In this tutorial we will walk through how to find a specific signal in LIGO data. We present matched filtering as a cross-correlation, in both the time domain and the frequency domain. In the next tutorial (2.2), we use the method as encoded in PyCBC, which is optimal in the case of Gaussian noise and a known signal model. In reality our noise is not entirely Gaussian, and in practice we use a variety of techniques to separate signals from noise in addition to the use of the matched filter. \n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw/blob/main/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb)\n",
     "\n",
-    "Additional [examples](http://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](http://pycbc.org/pycbc/latest/html/py-modindex.html)"
+    "Additional [examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](https://pycbc.org/pycbc/latest/html/py-modindex.html)"
    ]
   },
   {
@@ -358,7 +358,7 @@
    ],
    "source": [
     "%matplotlib inline\n",
-    "# http://pycbc.org/pycbc/latest/html/noise.html\n",
+    "# https://pycbc.org/pycbc/latest/html/noise.html\n",
     "import pycbc.noise\n",
     "import pycbc.psd\n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw/blob/main/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb)\n",
     "\n",
-    "Additional [examples](http://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](http://pycbc.org/pycbc/latest/html/py-modindex.html)"
+    "Additional [examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](https://pycbc.org/pycbc/latest/html/py-modindex.html)"
    ]
   },
   {

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "## Tutorial 2.2 PyCBC Tutorial, Matched Filtering in Action\n",
     "\n",
-    "We will be using the [PyCBC](http://github.com/ligo-cbc/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
+    "We will be using the [PyCBC](https://github.com/ligo-cbc/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
     "\n",
     "In this tutorial we will walk through how find a specific signal in LIGO data. We present matched filtering in PyCBC, which is optimal in the case of Gaussian noise and a known signal model. In reality our noise is not entirely Gaussian, and in practice we use a variety of techniques to separate signals from noise in addition to the use of the matched filter. \n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw/blob/main/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb)\n",
     "\n",
-    "Additional [examples](http://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](http://pycbc.org/pycbc/latest/html/py-modindex.html)"
+    "Additional [examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](https://pycbc.org/pycbc/latest/html/py-modindex.html)"
    ]
   },
   {
@@ -484,7 +484,7 @@
     "\n",
     "In this section we will determine how significant the peak in the Virgo re-weighted SNR time series is. \n",
     "\n",
-    "We will do this first by determining where one might expect a peak associated with an astrophysical source relative to the LIGO observed peaks. This is set by the constraint that an astrophysical source can only cause delays between observatories no larger than the light travel time between them. The [`pycbc.detector.Detector`](http://pycbc.org/pycbc/latest/html/pycbc.html#pycbc.detector.Detector) class provides some convenient methods to calculate the light travel time between detectors.\n",
+    "We will do this first by determining where one might expect a peak associated with an astrophysical source relative to the LIGO observed peaks. This is set by the constraint that an astrophysical source can only cause delays between observatories no larger than the light travel time between them. The [`pycbc.detector.Detector`](https://pycbc.org/pycbc/latest/html/pycbc.html#pycbc.detector.Detector) class provides some convenient methods to calculate the light travel time between detectors.\n",
     "\n",
     "We will then identify the largest peak in the SNR for this window around the LIGO observed peaks. This is our \"on-source\" window. \n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "## Tutorial 2.3: PyCBC Tutorial, Signal Consistency and Significance\n",
     "\n",
-    "We will be using the [PyCBC](http://github.com/gwastro/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
+    "We will be using the [PyCBC](https://github.com/gwastro/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
     "\n",
     "In this tutorial we will walk through finding a peak in a noisy timeseries and estimating its significance given a simplified search. Some assumptions will be noted along the way. We will also make use of one of the standard signal consistency tests to help remove some non-Gaussian transient noise from the background.\n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -401,7 +401,7 @@
     "\n",
     "$\\hat{\\rho} = \\frac{\\rho}{ \\frac{1}{2}[1 + (\\chi^2_r)^3]^{1/6}}$ where $\\chi^2 > 1$, otherwise $\\rho$\n",
     "\n",
-    "For reference on how we rank coincident (i.e. occurring in multiple detector) events in Advanced LIGO, there is a description [here](http://iopscience.iop.org/article/10.3847/1538-4357/aa8f50/pdf)."
+    "For reference on how we rank coincident (i.e. occurring in multiple detector) events in Advanced LIGO, there is a description [here](https://iopscience.iop.org/article/10.3847/1538-4357/aa8f50/pdf)."
    ]
   },
   {

--- a/Tutorials/Day_3/README.md
+++ b/Tutorials/Day_3/README.md
@@ -13,4 +13,4 @@ Click a badge below to run the notebooks
 ## More documentation
 
 * [bilby documentation](https://lscsoft.docs.ligo.org/bilby/index.html)
-* [PyCBC documentation](http://pycbc.org/pycbc/latest/html/)
+* [PyCBC documentation](https://pycbc.org/pycbc/latest/html/)

--- a/Tutorials/Day_3/README.md
+++ b/Tutorials/Day_3/README.md
@@ -8,7 +8,7 @@ Click a badge below to run the notebooks
 
 ## Challenge Questions
 
-* Answer associated challenge questions in the [online course](https://gw-odw.thinkific.com)
+* Answer associated challenge questions in the [online course](https://learn.gwosc.org)
 
 ## More documentation
 

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -644,7 +644,7 @@
     "id": "lv1EoAny3Dku"
    },
    "source": [
-    "We now compute the redshift value for all the samples (using only the distance value). See [astropy.cosmology](http://docs.astropy.org/en/stable/api/astropy.cosmology.z_at_value.html) for implementation details, in particular how to make the following more efficient:"
+    "We now compute the redshift value for all the samples (using only the distance value). See [astropy.cosmology](https://docs.astropy.org/en/stable/api/astropy.cosmology.z_at_value.html) for implementation details, in particular how to make the following more efficient:"
    ]
   },
   {

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -202,7 +202,7 @@
     "\n",
     "The PE files contains the PSD, calibration envelops and inference run configuration options, as well as the posterior samples from the `LALInference` runs performed by the LVK collaboration.\n",
     "\n",
-    "The file is retrieved and parsed using the `pesummary` package (more information on the [PESummary documentation](https://lscsoft.docs.ligo.org/pesummary/unstable_docs/index.html)).\n",
+    "The file is retrieved and parsed using the `pesummary` package (more information on the [PESummary documentation](https://lscsoft.docs.ligo.org/pesummary/reference/)).\n",
     "\n",
     "\n",
     "\n"

--- a/setup.md
+++ b/setup.md
@@ -11,7 +11,7 @@ This workshop uses [Python version 3.11](https://www.python.org/downloads/releas
 
 ## Option 1: Google Colab
 
-<img src='https://www.wispresort.com/uploadedImages/Winter/easy.png' width=20 /> Easy (No software installation; Works for any OS)
+🟢 Easy (No software installation; Works for any OS)
 
 <img src='./share/video-icon.png' width=18 /> [Video instructions](https://drive.google.com/file/d/17jYkGoVIavJa1B_Fbi6xK2D3jCFQT-A7/view?usp=sharing)
 
@@ -40,7 +40,7 @@ This workshop uses [Python version 3.11](https://www.python.org/downloads/releas
 
 ## Option 2: Run in mybinder
 
-<img src='https://www.wispresort.com/uploadedImages/Winter/easy.png' width=20 /> Easy (No software installation; Works for any OS) - Warning: note that `mybinder` can take several minutes to load.
+🟢 Easy (No software installation; Works for any OS) - Warning: note that `mybinder` can take several minutes to load.
 
 <img src='./share/video-icon.png' width=18 /> [Video instructions](https://drive.google.com/file/d/1QkjdG6IHeTWq2XtPreakLydaZMedJCrX/view?usp=sharing)
 
@@ -51,7 +51,7 @@ This will build a Docker image (if not already present) with the dependency file
 
 ## Option 3: You have a Linux or Apple/Mac computer -- Use conda
 
-<img src='https://www.wispresort.com/uploadedImages/Winter/intermediate.png' width=20 /> Intermediate (Some software installation; Will not work on Windows PC)
+🟡 Intermediate (Some software installation; Will not work on Windows PC)
 
 <img src='./share/video-icon.png' width=18 /> [Video instructions](https://drive.google.com/file/d/1YZcaY-35JiHXOH4unRe5ECSeDl8IZFZy/view?usp=sharing)
 
@@ -96,7 +96,7 @@ This guide will walk you through the configuration of this environment (named `o
 
 ## Option 4: Linux install on Windows with dedicated app (Windows 10 or 11)
 
-<img src='https://www.wispresort.com/uploadedImages/Winter/hard.png' width=20 /> Advanced (For Windows 10 or 11)
+🟠 Advanced (For Windows 10 or 11)
 
 If you are using Windows and would like to run the notebooks directly, install [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install). There are additional instructions [here](https://ask.igwn.org/t/run-the-workshops-under-windows-with-wsl/84) for getting started with the notebooks.
 Note that even if Conda works many packages needed for the Tutorials are not running on Windows at all, so we suggest to follow one of the previous options and not to run the Tutorials directly on Windows.


### PR DESCRIPTION
This PR tackles #26.

We update broken links as reported by `lychee` and use HTTPS when possible.

A few cases couldn't be solved:
- The gwosc client returns HTTP URLs which are printed; `lychee` catches this as invalid but we can fix it so we add them to `.lycheeignore`.
- `https://gw-odw.thinkific.com/` seems to return `403` from GitHub but not when checking locally. Changing it to `https://learn.gwosc.org` didn't solve the problem so we add the latter to `.lycheeignore`.

# Tasks

- [x] `https://gw-odw.thinkific.com/` seems to return `403` here but not when running locally. Is that specific to GitHub ?