### PR TITLE
Remove http exceptions on .lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -32,10 +32,3 @@ https://doi.org/10.1088/0264-9381/21/20/024
 # It returns 403 from GitHub actions
 # We believe it's because Thinkific (which eventually answers) blocks GitHub IPs
 https://learn.gwosc.org
-
-# The GWOSC server returns http URLs
-# We ignore them for now
-http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126259447-32.hdf5
-http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126257415-4096.hdf5
-http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126259447-32.hdf5
-http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126257415-4096.hdf5

--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -390,7 +390,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126259447-32.hdf5', 'http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126257415-4096.hdf5', 'http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126259447-32.hdf5', 'http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126257415-4096.hdf5']\n"
+      "['https://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126259447-32.hdf5', 'https://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/H-H1_GWOSC_4KHZ_R1-1126257415-4096.hdf5', 'https://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126259447-32.hdf5', 'https://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126257415-4096.hdf5']\n"
      ]
     }
    ],
@@ -429,7 +429,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['http://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126259447-32.hdf5']\n"
+      "['https://gwosc.org/eventapi/json/GWTC-1-confident/GW150914/v3/L-L1_GWOSC_4KHZ_R1-1126259447-32.hdf5']\n"
      ]
     }
    ],


### PR DESCRIPTION
Now that gwosc.org's backend fixed its issue returning links with http (instead of using https) we can remove the exceptions introduced in .lycheeignore file.