### PR TITLE
Make bilby silent

### DIFF
--- a/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
+++ b/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
@@ -121,6 +121,9 @@
     "import bilby\n",
     "import corner\n",
     "\n",
+    "# Make bilby more terse\n",
+    "bilby.core.utils.log.setup_logger(log_level='WARNING')\n",
+    "\n",
     "for module in [np, matplotlib, bilby, corner]:\n",
     "    print(f\"Loaded {module.__name__}: {module.__version__}\")"
    ]
@@ -637,85 +640,24 @@
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.09e+04|0:00:02|7.18e+02(10tau)|t=11|n=905|a=0.43|e=8.3e+00%|0.18ms/ev|maxl=25.99|ETF=0:00:00\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "16:05 bilby INFO    : Running for label 'model_Ms', output will be saved to 'toy_model'\n",
-      "16:05 bilby INFO    : Analysis priors:\n",
-      "16:05 bilby INFO    : freq=Uniform(minimum=0, maximum=5, name=None, latex_label=None, unit=None, boundary=None)\n",
-      "16:05 bilby INFO    : alpha=Uniform(minimum=0, maximum=1, name=None, latex_label=None, unit=None, boundary=None)\n",
-      "16:05 bilby INFO    : Analysis likelihood class: <class 'bilby.core.likelihood.GaussianLikelihood'>\n",
-      "16:05 bilby INFO    : Analysis likelihood noise evidence: nan\n",
-      "16:05 bilby INFO    : Single likelihood evaluation took 2.582e-05 s\n",
-      "16:05 bilby INFO    : Using sampler Bilby_MCMC with kwargs {'nsamples': 1000, 'nensemble': 1, 'pt_ensemble': False, 'ntemps': 1, 'Tmax': None, 'Tmax_from_SNR': 20, 'initial_betas': None, 'adapt': True, 'adapt_t0': 100, 'adapt_nu': 10, 'pt_rejection_sample': False, 'burn_in_nact': 10, 'thin_by_nact': 1, 'fixed_discard': 0, 'autocorr_c': 5, 'L1steps': 1, 'L2steps': 3, 'printdt': 2, 'check_point_delta_t': 1800, 'min_tau': 1, 'proposal_cycle': 'default', 'stop_after_convergence': False, 'fixed_tau': None, 'tau_window': None, 'evidence_method': 'stepping_stone', 'initial_sample_method': 'prior', 'initial_sample_dict': None}\n",
-      "16:05 bilby INFO    : Initializing BilbyPTMCMCSampler with:\n",
-      "  Convergence settings: ConvergenceInputs(autocorr_c=5, burn_in_nact=10, thin_by_nact=1, fixed_discard=0, target_nsamples=1000, stop_after_convergence=False, L1steps=1, L2steps=3, min_tau=1, fixed_tau=None, tau_window=None)\n",
-      "  Parallel-tempering settings: ParallelTemperingInputs(ntemps=1, nensemble=1, Tmax=None, Tmax_from_SNR=20, initial_betas=None, adapt=True, adapt_t0=100, adapt_nu=10, pt_ensemble=False)\n",
-      "  proposal_cycle: default\n",
-      "  pt_rejection_sample: False\n",
-      "16:05 bilby INFO    : Setting parallel tempering inputs=ParallelTemperingInputs(ntemps=1, nensemble=1, Tmax=None, Tmax_from_SNR=20, initial_betas=None, adapt=True, adapt_t0=100, adapt_nu=10, pt_ensemble=False)\n",
-      "16:05 bilby INFO    : Initializing BilbyPTMCMCSampler with:ntemps=1, nensemble=1, pt_ensemble=False, initial_betas=[1], initial_sample_method=prior, initial_sample_dict=None\n",
-      "\n",
-      "16:05 bilby INFO    : Using initial sample {'freq': 4.549780111581857, 'alpha': 0.36886574385534965}\n",
-      "16:05 bilby INFO    : Using ProposalCycle:\n",
-      "  AdaptiveGaussianProposal(acceptance_ratio:nan,n:0,scale:1,)\n",
-      "  DifferentialEvolutionProposal(acceptance_ratio:nan,n:0,)\n",
-      "  UniformProposal(acceptance_ratio:nan,n:0,)\n",
-      "  KDEProposal(acceptance_ratio:nan,n:0,trained:0,)\n",
-      "  FisherMatrixProposal(acceptance_ratio:nan,n:0,scale:1,)\n",
-      "  GMMProposal(acceptance_ratio:nan,n:0,trained:0,)\n",
-      "\n",
-      "16:05 bilby INFO    : Setting convergence_inputs=ConvergenceInputs(autocorr_c=5, burn_in_nact=10, thin_by_nact=1, fixed_discard=0, target_nsamples=1000, stop_after_convergence=False, L1steps=1, L2steps=3, min_tau=1, fixed_tau=None, tau_window=None)\n",
-      "16:05 bilby INFO    : Drawing 1000 samples\n",
-      "16:05 bilby INFO    : Checkpoint every check_point_delta_t=1800s\n",
-      "16:05 bilby INFO    : Print update every printdt=2s\n"
+      "14:07 bilby WARNING : Non-negligible print progress time (ppt_frac=0.04)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.24e+04|0:00:02|1.05e+03(10tau)|t=13|n=867|a=0.41|e=7.0e+00%|0.16ms/ev|maxl=25.98|ETF=0:00:00\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16:05 bilby WARNING : Non-negligible print progress time (ppt_frac=0.05)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.26e+04|0:00:04|6.44e+02(z1)|t=13|n=1675|a=0.46|e=7.4e+00%|0.20ms/ev|maxl=25.99|ETF=0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16:05 bilby INFO    : Reached convergence: exiting sampling\n",
-      "16:05 bilby INFO    : Checkpoint start\n",
-      "16:05 bilby INFO    : Written checkpoint file toy_model/model_Ms_resume.pickle\n",
-      "16:05 bilby INFO    : Zero-temperature proposals:\n",
-      "16:05 bilby INFO    : AdaptiveGaussianProposal(acceptance_ratio:0.23,n:4.6e+03,scale:0.024,)\n",
-      "16:05 bilby INFO    : DifferentialEvolutionProposal(acceptance_ratio:0.47,n:4.3e+03,)\n",
-      "16:05 bilby INFO    : UniformProposal(acceptance_ratio:1,n:1.6e+02,)\n",
-      "16:05 bilby INFO    : KDEProposal(acceptance_ratio:0.48,n:4.7e+03,trained:1,)\n",
-      "16:05 bilby INFO    : FisherMatrixProposal(acceptance_ratio:0.54,n:4.5e+03,scale:1,)\n",
-      "16:05 bilby INFO    : GMMProposal(acceptance_ratio:0.57,n:4.3e+03,trained:1,)\n",
-      "16:05 bilby INFO    : Current taus={'freq': 7.9, 'alpha': 7.7}\n",
-      "16:05 bilby INFO    : Creating diagnostic plots\n",
-      "16:05 bilby INFO    : Checkpoint finished\n",
-      "16:05 bilby INFO    : Sampling time: 0:00:04.000144\n",
-      "16:05 bilby INFO    : Summary of results:\n",
-      "nsamples: 3136\n",
-      "ln_noise_evidence:    nan\n",
-      "ln_evidence:    nan +/-    nan\n",
-      "ln_bayes_factor:    nan +/-    nan\n",
-      "\n"
+      "2.10e+04|0:00:04|2.40e+02(z1)|t=11|n=1853|a=0.50|e=8.8e+00%|0.20ms/ev|maxl=25.99|ETF=0\n"
      ]
     }
    ],

--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -108,6 +108,9 @@
     "from bilby.core.prior import Uniform, PowerLaw\n",
     "from bilby.gw.conversion import convert_to_lal_binary_black_hole_parameters, generate_all_bbh_parameters\n",
     "\n",
+    "# Make bilby more terse\n",
+    "bilby.core.utils.log.setup_logger(log_level='WARNING')\n",
+    "\n",
     "from gwpy.timeseries import TimeSeries"
    ]
   },
@@ -518,19 +521,7 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16:08 bilby INFO    : Waveform generator initiated with\n",
-      "  frequency_domain_source_model: bilby.gw.source.lal_binary_black_hole\n",
-      "  time_domain_source_model: None\n",
-      "  parameter_conversion: bilby.gw.conversion.convert_to_lal_binary_black_hole_parameters\n",
-      "16:08 bilby INFO    : Loaded distance marginalisation lookup table from .distance_marginalization_lookup.npz.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# First, put our \"data\" created above into a list of interferometers (the order is arbitrary)\n",
     "interferometers = [H1, L1]\n",
@@ -592,45 +583,9 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16:08 bilby INFO    : Running for label 'GW150914', output will be saved to 'short'\n",
-      "16:08 bilby INFO    : Using lal version 7.6.1\n",
-      "16:08 bilby INFO    : Using lal git version Branch: None;Tag: lal-v7.6.1;Id: 31af23159ed7c6557180f58ad3f39a06e5a08731;;Builder: Adam Mercer <adam.mercer@ligo.org>;Repository status: CLEAN: All modifications committed\n",
-      "16:08 bilby INFO    : Using lalsimulation version 6.1.0\n",
-      "16:08 bilby INFO    : Using lalsimulation git version Branch: None;Tag: lalsimulation-v6.1.0;Id: 8041734408377ca999821f7e372e2a02e9226e6b;;Builder: Adam Mercer <adam.mercer@ligo.org>;Repository status: CLEAN: All modifications committed\n",
-      "16:08 bilby INFO    : Analysis priors:\n",
-      "16:08 bilby INFO    : chirp_mass=Uniform(minimum=30.0, maximum=32.5, name='chirp_mass', latex_label='$\\\\mathcal{M}$', unit=None, boundary=None)\n",
-      "16:08 bilby INFO    : mass_ratio=Uniform(minimum=0.5, maximum=1, name='mass_ratio', latex_label='$q$', unit=None, boundary=None)\n",
-      "16:08 bilby INFO    : time_jitter=Uniform(minimum=-0.000244140625, maximum=0.000244140625, name='time_jitter', latex_label='$t_j$', unit=None, boundary='periodic')\n",
-      "16:08 bilby INFO    : phase=0.0\n",
-      "16:08 bilby INFO    : geocent_time=1126259460.3999023\n",
-      "16:08 bilby INFO    : a_1=0.0\n",
-      "16:08 bilby INFO    : a_2=0.0\n",
-      "16:08 bilby INFO    : tilt_1=0.0\n",
-      "16:08 bilby INFO    : tilt_2=0.0\n",
-      "16:08 bilby INFO    : phi_12=0.0\n",
-      "16:08 bilby INFO    : phi_jl=0.0\n",
-      "16:08 bilby INFO    : dec=-1.2232\n",
-      "16:08 bilby INFO    : ra=2.19432\n",
-      "16:08 bilby INFO    : theta_jn=1.89694\n",
-      "16:08 bilby INFO    : psi=0.532268\n",
-      "16:08 bilby INFO    : luminosity_distance=1587.4093196389506\n",
-      "16:08 bilby INFO    : Analysis likelihood class: <class 'bilby.gw.likelihood.base.GravitationalWaveTransient'>\n",
-      "16:08 bilby INFO    : Analysis likelihood noise evidence: -8534.56163362428\n",
-      "16:08 bilby INFO    : Single likelihood evaluation took 3.984e-03 s\n",
-      "16:08 bilby INFO    : Using sampler Dynesty with kwargs {'nlive': 250, 'bound': 'live', 'sample': 'act-walk', 'periodic': None, 'reflective': None, 'update_interval': 600, 'first_update': None, 'npdim': None, 'rstate': None, 'queue_size': 1, 'pool': None, 'use_pool': None, 'live_points': None, 'logl_args': None, 'logl_kwargs': None, 'ptform_args': None, 'ptform_kwargs': None, 'gradient': None, 'grad_args': None, 'grad_kwargs': None, 'compute_jac': False, 'enlarge': None, 'bootstrap': None, 'walks': 100, 'facc': 0.2, 'slices': None, 'fmove': 0.9, 'max_move': 100, 'update_func': None, 'ncdim': None, 'blob': False, 'save_history': False, 'history_filename': None, 'maxiter': None, 'maxcall': None, 'dlogz': 1.0, 'logl_max': inf, 'n_effective': None, 'add_live': True, 'print_progress': True, 'print_func': <bound method Dynesty._print_func of <bilby.core.sampler.dynesty.Dynesty object at 0x172a369d0>>, 'save_bounds': False, 'checkpoint_file': None, 'checkpoint_every': 60, 'resume': False, 'seed': None}\n",
-      "16:08 bilby INFO    : Checkpoint every check_point_delta_t = 600s\n",
-      "16:08 bilby INFO    : Using dynesty version 2.1.5\n",
-      "16:08 bilby INFO    : Using the bilby-implemented act-walk sampling tracking the autocorrelation function and thinning by 2 with maximum length 10000\n",
-      "16:08 bilby INFO    : Generating initial points from the prior\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "82e8c04bd2394d43bb4a451f8aea9de5",
+       "model_id": "1dbd4599c96c499fb463adf8b7ecb84d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -642,16 +597,6 @@
      "output_type": "display_data"
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16:08 bilby INFO    : Written checkpoint file short/GW150914_resume.pickle\n",
-      "16:08 bilby INFO    : Rejection sampling nested samples to obtain 293 posterior samples\n",
-      "16:08 bilby INFO    : Sampling time: 0:00:17.515908\n",
-      "16:08 bilby INFO    : Computing per-detector log likelihoods.\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -661,91 +606,58 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bec69310ad3b4c9aab6c73e3efa29137",
+       "model_id": "1a1cf9a0b8284fb5af90ab4673d9e0d8",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "  0%|          | 0/293 [00:00<?, ?it/s]"
+       "  0%|          | 0/283 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16:08 bilby INFO    : Reconstructing marginalised parameters.\n"
-     ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1f0ff4b912234e599076b40e16dafce8",
+       "model_id": "c42cd7e538c34ae9bf9979b3d748d096",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "  0%|          | 0/293 [00:00<?, ?it/s]"
+       "  0%|          | 0/283 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16:08 bilby INFO    : Generating sky frame parameters.\n"
-     ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "23cf74a7036d4b43b276b1584ebf2755",
+       "model_id": "36a696c6d40149c0bb14cbdee27921eb",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "  0%|          | 0/293 [00:00<?, ?it/s]"
+       "  0%|          | 0/283 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16:08 bilby INFO    : Computing SNRs for every sample.\n"
-     ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "36808907bca74946b3d69e36f49557a9",
+       "model_id": "76384db254794f62a9a7d142360d26cb",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "  0%|          | 0/293 [00:00<?, ?it/s]"
+       "  0%|          | 0/283 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "16:08 bilby INFO    : Summary of results:\n",
-      "nsamples: 293\n",
-      "ln_noise_evidence: -8534.562\n",
-      "ln_evidence: -8250.027 +/-  0.207\n",
-      "ln_bayes_factor: 284.535 +/-  0.207\n",
-      "\n"
-     ]
     }
    ],
    "source": [

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -750,6 +750,10 @@
    ],
    "source": [
     "import bilby\n",
+    "\n",
+    "# Make bilby more terse\n",
+    "bilby.core.utils.log.setup_logger(log_level='WARNING')\n",
+    "\n",
     "# calculate the detector frame chirp mass\n",
     "mchirp = ((samples['m1_detector_frame_Msun'] * samples['m2_detector_frame_Msun'])**(3./5))/\\\n",
     "         (samples['m1_detector_frame_Msun'] + samples['m2_detector_frame_Msun'])**(1./5)\n",


### PR DESCRIPTION
This PR addresses the verbosity of bilby reported in #32.

To do so, we use `bilby.core.utils.log.setup_logger(log_level='WARNING')`. There output cells are much shorter hence the large diffs on some of them.

This mainly concern tutorials 3.1 and 3.2 but I applied this to tutorial 3.3 too.