### PR TITLE
Downgrade scipy on Google Colab for Tutorial 2.2

### DIFF
--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -62,7 +62,7 @@
    "outputs": [],
    "source": [
     "# -- Use the following for Google Colab\n",
-    "#! pip install -q 'lalsuite==7.25' 'PyCBC==2.4.1'"
+    "#! pip install -q -U 'scipy==1.12.0' 'lalsuite==7.25' 'PyCBC==2.4.1'"
    ]
   },
   {


### PR DESCRIPTION
This PR addresses the error in Tutorial 2.2 reported in #33 and #40.

To do this, we downgrade `scipy` to 1.12.0 when installing packages for Colab.

**Given the user restarts the kernel after installation** (as explained in the notebook), the notebook should run. 