### PR TITLE
PyCBC links

### DIFF
--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -361,7 +361,7 @@
     "id": "1irX8-UnvvXd"
    },
    "source": [
-    "Note: There are alternative ways to access GWOSC data. The [PyCBC](https://github.com/ligo-cbc/pycbc) package has the `pycbc.frame.query_and_read_frame` and `pycbc.frame.read_frame` methods that we will learn in tutorials 2.1 to 2.3."
+    "Note: There are alternative ways to access GWOSC data. The [PyCBC](https:/pycbc.org) package has the `pycbc.frame.query_and_read_frame` and `pycbc.frame.read_frame` methods that we will learn in tutorials 2.1 to 2.3."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "This tutorial shows how to numerically obtain the gravitational waveform radiated during a compact binary coalescence, assuming the basic parameters of the binary are known.\n",
     "\n",
-    "We will be using the [PyCBC](https://github.com/ligo-cbc/pycbc) library, which provides an easy-to-use Python interface to obtain such waveforms. PyCBC can more generally be used to analyze or simulate gravitational-wave data, find or simulate astrophysical signals from compact binary mergers, and study their parameters. It is one of the tools routinely used by groups within and outside of the LIGO and Virgo collaborations. Additional [examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](https://pycbc.org/pycbc/latest/html/py-modindex.html).\n",
+    "We will be using the [PyCBC](https://pycbc.org) library, which provides an easy-to-use Python interface to obtain such waveforms. PyCBC can more generally be used to analyze or simulate gravitational-wave data, find or simulate astrophysical signals from compact binary mergers, and study their parameters. It is one of the tools routinely used by groups within and outside of the LIGO and Virgo collaborations. See [additional examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and [documentation](https://pycbc.org/pycbc/latest/html/index.html).\n",
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw/blob/main/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb)"
    ]

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw/blob/main/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb)\n",
     "\n",
-    "Additional [examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](https://pycbc.org/pycbc/latest/html/py-modindex.html)"
+    "See [additional examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and [documentation](https://pycbc.org/pycbc/latest/html/index.html)."
    ]
   },
   {

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "## Tutorial 2.1 PyCBC Tutorial, An introduction to matched-filtering\n",
     "\n",
-    "We will be using the [PyCBC](https://github.com/ligo-cbc/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
+    "We will be using the [PyCBC](https://pycbc.org) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
     "\n",
     "In this tutorial we will walk through how to find a specific signal in LIGO data. We present matched filtering as a cross-correlation, in both the time domain and the frequency domain. In the next tutorial (2.2), we use the method as encoded in PyCBC, which is optimal in the case of Gaussian noise and a known signal model. In reality our noise is not entirely Gaussian, and in practice we use a variety of techniques to separate signals from noise in addition to the use of the matched filter. \n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -160,7 +160,7 @@
     "id": "sHJcsujM1zu1"
    },
    "source": [
-    "_Note_: To read data from a local file instead of from the GWOSC server, we can use the [`pycbc.frame.read_frame(file, channel_name)`](https://github.com/gwastro/pycbc/blob/master/docs/frame.rst) method."
+    "_Note_: To read data from a local file instead of from the GWOSC server, we can use the [pycbc.frame.read_frame](https://pycbc.org/pycbc/latest/html/pycbc.frame.html#pycbc.frame.frame.read_frame) method (see also [this page](https://pycbc.org/pycbc/latest/html/frame.html))."
    ]
   },
   {

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw/blob/main/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb)\n",
     "\n",
-    "Additional [examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](https://pycbc.org/pycbc/latest/html/py-modindex.html)"
+    "See [additional examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and [documentation](https://pycbc.org/pycbc/latest/html/index.html)."
    ]
   },
   {

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "## Tutorial 2.2 PyCBC Tutorial, Matched Filtering in Action\n",
     "\n",
-    "We will be using the [PyCBC](https://github.com/ligo-cbc/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
+    "We will be using the [PyCBC](https://pycbc.org) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
     "\n",
     "In this tutorial we will walk through how find a specific signal in LIGO data. We present matched filtering in PyCBC, which is optimal in the case of Gaussian noise and a known signal model. In reality our noise is not entirely Gaussian, and in practice we use a variety of techniques to separate signals from noise in addition to the use of the matched filter. \n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "## Tutorial 2.3: PyCBC Tutorial, Signal Consistency and Significance\n",
     "\n",
-    "We will be using the [PyCBC](https://github.com/gwastro/pycbc) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
+    "We will be using the [PyCBC](https://pycbc.org) library, which is used to study gravitational-wave data, find astrophysical sources due to compact binary mergers, and study their parameters. These are some of the same tools that the LIGO and Virgo collaborations use to find gravitational waves in LIGO/Virgo data \n",
     "\n",
     "In this tutorial we will walk through finding a peak in a noisy timeseries and estimating its significance given a simplified search. Some assumptions will be noted along the way. We will also make use of one of the standard signal consistency tests to help remove some non-Gaussian transient noise from the background.\n",
     "\n",

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "[Click this link to view this tutorial in Google Colaboratory](https://colab.research.google.com/github/gw-odw/odw/blob/main/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb)\n",
     "\n",
-    "Additional [examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and module level documentation are [here](https://pycbc.org/pycbc/latest/html/py-modindex.html)"
+    "See [additional examples](https://pycbc.org/pycbc/latest/html/#library-examples-and-interactive-tutorials) and [documentation](https://pycbc.org/pycbc/latest/html/index.html)."
    ]
   },
   {


### PR DESCRIPTION
This PR addresses the problem of PyCBC URLs pointed out in #31. We go beyond this by updating all PyCBC URLs.

The changes are the following:
- don't point to the module index but to the general help (this was the problem in #31)
- point to pycbc.org instead of the GitHub repo
- correctly point to method doc

Note that we use the latest version of the documentation which might vary slightly from the one we use.