### PR TITLE
Make warnings for Google Colab more visible

### DIFF
--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -41,11 +41,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -43,7 +43,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/Day_1/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -5,7 +5,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "R_adEak0Q8NT"
+    "editable": true,
+    "id": "R_adEak0Q8NT",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -27,9 +32,20 @@
     "id": "W6msjCJVQ8NV"
    },
    "source": [
-    "## Software installation  (execute only if running on a cloud platform or haven't done the installation yet!)\n",
+    "## Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)\n",
     "\n",
     "First, we need to install the software, which we do following the instruction in [Software Setup Instructions](../../setup.md):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -40,6 +56,13 @@
    "source": [
     "# -- Uncomment following line if running in Google Colab\n",
     "#! pip install -q 'gwosc==0.7.1'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization"
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -54,11 +54,9 @@
     "id": "KSHN5q5MvvW3"
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -5,7 +5,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "tcXQnfN0vvWt"
+    "editable": true,
+    "id": "tcXQnfN0vvWt",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -38,7 +43,22 @@
     "id": "AXkLJmTgvvWw"
    },
    "source": [
-    "##  Installation  (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
+    "## Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "Collapsed": "false",
+    "colab_type": "text",
+    "id": "KSHN5q5MvvW3"
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -58,17 +78,6 @@
    "source": [
     "# -- Uncomment following line if running in Google Colab\n",
     "#! pip install -q 'gwpy==3.0.12'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false",
-    "colab_type": "text",
-    "id": "KSHN5q5MvvW3"
-   },
-   "source": [
-    "**Important:** With Google Colab, you may need to restart the runtime after running the cell above."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
+++ b/Tutorials/Day_1/Tuto_1.2_Open_Data_access_with_GWpy.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -72,11 +72,9 @@
     "tags": []
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -5,7 +5,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "_aI2xJ4qzarB"
+    "editable": true,
+    "id": "_aI2xJ4qzarB",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -24,7 +29,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Those 2 lines are just to avoid some harmless warnings when importing packages\n",
@@ -37,12 +48,35 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "1wcq0imbzarE"
+    "editable": true,
+    "id": "1wcq0imbzarE",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
-    "##  Installation  (execute only if running on a cloud platform or if you haven't done the installation already!)\n",
-    "\n",
-    "PyCBC is installable through pip. It relies on portions of the [LALSuite](https://lscsoft.docs.ligo.org/lalsuite/) C-library. A bundled version of this suitable for use with PyCBC is also available on Mac / Linux through pip. **It is recommended** to use [conda](https://docs.ligo.org/lscsoft/conda/) on your own machine, as explained in the [installation instructions](../../setup.md). This usage might look a little different than normal, simply because we want to do this directly from the notebook."
+    "## Installation (execute only if running on a cloud platform or if you haven't done the installation already!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "Collapsed": "false",
+    "colab_type": "text",
+    "editable": true,
+    "id": "wHDzqNw3zarK",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -55,8 +89,12 @@
      "height": 1000
     },
     "colab_type": "code",
+    "editable": true,
     "id": "UfyiwG64zarG",
     "outputId": "123979cf-adbf-4144-ff8a-25c26625ee95",
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "outputs": [],
@@ -70,18 +108,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "wHDzqNw3zarK"
-   },
-   "source": [
-    "**Important:** With Google Colab, you may need to restart the runtime after running the cell above."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false",
-    "colab_type": "text",
-    "id": "HwA6949mzarL"
+    "editable": true,
+    "id": "HwA6949mzarL",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "## Initialization"
@@ -108,7 +140,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "u9i3C2HAzarT"
+    "editable": true,
+    "id": "u9i3C2HAzarT",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "### Generate your first waveform!\n",
@@ -124,6 +161,10 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "outputs": [
@@ -404,7 +445,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }
@@ -432,7 +479,6 @@
    "version": "3.11.11"
   },
   "toc": {
-   "base_numbering": 1,
    "nav_menu": {},
    "number_sections": true,
    "sideBar": true,
@@ -441,7 +487,7 @@
    "title_sidebar": "Contents",
    "toc_cell": false,
    "toc_position": {},
-   "toc_section_display": true,
+   "toc_section_display": false,
    "toc_window_display": false
   }
  },

--- a/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
+++ b/Tutorials/Day_1/Tuto_1.4_Generating_waveforms.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -5,7 +5,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "D_QUDECR0psB"
+    "editable": true,
+    "id": "D_QUDECR0psB",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -39,11 +44,35 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
+    "editable": true,
     "id": "VfuWmS4z0psH",
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "source": [
-    "## Installation (un-comment and execute only if running on a cloud platform!)"
+    "## Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "Collapsed": "false",
+    "colab_type": "text",
+    "editable": true,
+    "id": "bkT6oEIq0psO",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -56,8 +85,13 @@
      "height": 1000
     },
     "colab_type": "code",
+    "editable": true,
     "id": "-oaVmOkc0psJ",
-    "outputId": "d6785c31-f774-45be-8b42-51c4e777b80d"
+    "outputId": "d6785c31-f774-45be-8b42-51c4e777b80d",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -70,18 +104,11 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "bkT6oEIq0psO"
-   },
-   "source": [
-    "**Important:** With Google Colab, you may need to restart the runtime after running the cell above."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false",
-    "colab_type": "text",
+    "editable": true,
     "id": "n1n6Ut_v0psP",
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "source": [
@@ -453,8 +480,13 @@
      "height": 297
     },
     "colab_type": "code",
+    "editable": true,
     "id": "d_HLbCCN0psi",
-    "outputId": "a5b15941-1ea8-4726-fe80-f08462a8a627"
+    "outputId": "a5b15941-1ea8-4726-fe80-f08462a8a627",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -503,7 +535,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }

--- a/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/Day_2/Tuto_2.1_Matched_filtering_introduction.ipynb
@@ -68,11 +68,9 @@
     "tags": []
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -68,11 +68,9 @@
     "tags": []
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
+++ b/Tutorials/Day_2/Tuto_2.2_Matched_Filtering_In_action.ipynb
@@ -5,7 +5,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "d9O1zsAO1zul"
+    "editable": true,
+    "id": "d9O1zsAO1zul",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -39,10 +44,35 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "chV5GUKV1zup"
+    "editable": true,
+    "id": "chV5GUKV1zup",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
-    "## Installation (execute only if running on a cloud platform!)"
+    "## Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "Collapsed": "false",
+    "colab_type": "text",
+    "editable": true,
+    "id": "KkcI-Bah1zuw",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -55,8 +85,12 @@
      "height": 1000
     },
     "colab_type": "code",
+    "editable": true,
     "id": "hPydO5B_1zuq",
     "outputId": "e752e5f2-dbec-4b3b-f23b-c751dbe71d91",
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "outputs": [],
@@ -70,18 +104,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "KkcI-Bah1zuw"
-   },
-   "source": [
-    "**Important:** With Google Colab, you may need to restart the runtime after running the cell above."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false",
-    "colab_type": "text",
-    "id": "cJ9NEh-q1zuw"
+    "editable": true,
+    "id": "cJ9NEh-q1zuw",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "## Looking for a specific signal in the data\n",
@@ -625,7 +653,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "mTPmoPRV1zvM"
+    "editable": true,
+    "id": "mTPmoPRV1zvM",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "## Challenge!\n",
@@ -694,7 +727,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -5,7 +5,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "omeA9c5XCLJJ"
+    "editable": true,
+    "id": "omeA9c5XCLJJ",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -39,10 +44,35 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "U5rEJwqoCLJM"
+    "editable": true,
+    "id": "U5rEJwqoCLJM",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
-    "## Installation (execute only if running on a cloud platform!)"
+    "## Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "Collapsed": "false",
+    "colab_type": "text",
+    "editable": true,
+    "id": "3266wGrJCLJS",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -55,8 +85,13 @@
      "height": 1000
     },
     "colab_type": "code",
+    "editable": true,
     "id": "5FB3HBEhCLJO",
-    "outputId": "a1395fec-64fd-49bc-9525-724700b5c395"
+    "outputId": "a1395fec-64fd-49bc-9525-724700b5c395",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -69,18 +104,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "3266wGrJCLJS"
-   },
-   "source": [
-    "**Important:** With Google Colab, you may need to restart the runtime after running the cell above."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false",
-    "colab_type": "text",
-    "id": "dCZ7ctknCLJT"
+    "editable": true,
+    "id": "dCZ7ctknCLJT",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "### Significance of Virgo SNR peak of GW170814 ###\n",
@@ -713,7 +742,12 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "Collapsed": "false"
+    "Collapsed": "false",
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -754,7 +788,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "Collapsed": "false"
+    "Collapsed": "false",
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/Day_2/Tuto_2.3_Signal_consistency_and_significance.ipynb
@@ -68,11 +68,9 @@
     "tags": []
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
+++ b/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
@@ -4,7 +4,12 @@
    "cell_type": "markdown",
    "id": "a2a21b4e",
    "metadata": {
-    "id": "a2a21b4e"
+    "editable": true,
+    "id": "a2a21b4e",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -23,9 +28,34 @@
   {
    "cell_type": "markdown",
    "id": "ba406484",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
-    "## Installation"
+    "## Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c21ebf7",
+   "metadata": {
+    "editable": true,
+    "id": "1c21ebf7",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -36,24 +66,18 @@
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "editable": true,
     "id": "f2014c53",
     "outputId": "9f90781c-60e4-4adb-d840-d4b55d8ac51e",
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "outputs": [],
    "source": [
     "# -- Use the following line in Google Colab\n",
     "#! pip install -q bilby==2.4.0 matplotlib==3.10.0 dynesty==2.1.5 corner==2.2.3"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1c21ebf7",
-   "metadata": {
-    "id": "1c21ebf7"
-   },
-   "source": [
-    "**Important:** With Google Colab, you may need to restart the runtime after running the cell above."
    ]
   },
   {
@@ -879,7 +903,12 @@
    "cell_type": "markdown",
    "id": "6dacade6",
    "metadata": {
-    "id": "6dacade6"
+    "editable": true,
+    "id": "6dacade6",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "Let's compare our rejection sampling results with the `bilby_mcmc` results. To do this, we will create a histogram of the $f$ samples for both:"
@@ -1092,7 +1121,12 @@
    "execution_count": null,
    "id": "2f8fc050",
    "metadata": {
-    "id": "2f8fc050"
+    "editable": true,
+    "id": "2f8fc050",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []

--- a/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
+++ b/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
@@ -51,11 +51,9 @@
     "tags": []
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
+++ b/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -69,7 +69,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -67,11 +67,9 @@
     "tags": []
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/Day_3/Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -5,7 +5,12 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "OjUNeFsxyguu"
+    "editable": true,
+    "id": "OjUNeFsxyguu",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -38,10 +43,35 @@
    "metadata": {
     "Collapsed": "false",
     "colab_type": "text",
-    "id": "VwsIdKJ3yguv"
+    "editable": true,
+    "id": "VwsIdKJ3yguv",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
-    "##  Installation  (execute only if running on a cloud platform!)"
+    "## Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "Collapsed": "false",
+    "colab_type": "text",
+    "editable": true,
+    "id": "f0q3Y_9gygu0",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -54,25 +84,18 @@
      "height": 1000
     },
     "colab_type": "code",
+    "editable": true,
     "id": "eJeo4XrHyguw",
     "outputId": "fc1a59d8-8ad9-494f-e7a1-9ac9b0775a9f",
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "outputs": [],
    "source": [
     "# -- Use the following line in Google Colab\n",
     "#! pip install -q bilby==2.4.0 matplotlib==3.10.0 dynesty==2.1.5 corner==2.2.3 gwpy==3.0.12 lalsuite==7.25"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false",
-    "colab_type": "text",
-    "id": "f0q3Y_9gygu0"
-   },
-   "source": [
-    "**Important:** With Google Colab, you may need to restart the runtime after running the cell above."
    ]
   },
   {
@@ -1373,7 +1396,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## Challenge questions\n",
     "First, let's take a closer look at the result obtained with the run above. What are the means of the chirp mass and mass ratio distributions? What are the medians of the distributions for the components masses? You can use `np.mean` and `np.median` to calculate these.\n",
@@ -1387,7 +1416,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -4,7 +4,12 @@
    "cell_type": "markdown",
    "metadata": {
     "Collapsed": "false",
-    "id": "quA5zQqJ3DkE"
+    "editable": true,
+    "id": "quA5zQqJ3DkE",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -24,10 +29,34 @@
    "cell_type": "markdown",
    "metadata": {
     "Collapsed": "false",
-    "id": "taEFmvys3DkG"
+    "editable": true,
+    "id": "taEFmvys3DkG",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
-    "## Installation (execute only if running on a cloud platform!)¶"
+    "## Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "Collapsed": "false",
+    "editable": true,
+    "id": "qrBuraTe3DkK",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -35,23 +64,17 @@
    "execution_count": 1,
    "metadata": {
     "Collapsed": "false",
+    "editable": true,
     "id": "Z2fAXT1v3DkH",
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "outputs": [],
    "source": [
     "# -- Use the following line for google colab removing the hash at the beginning.\n",
     "#! pip install -q 'corner==2.2.3' 'bilby==2.4.0' 'astropy==7.0.1' "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "Collapsed": "false",
-    "id": "qrBuraTe3DkK"
-   },
-   "source": [
-    "**Important**: With Google Colab, you may need to restart the runtime after running the cell above."
    ]
   },
   {
@@ -720,7 +743,12 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "7x-iQAjXsMs1"
+    "editable": true,
+    "id": "7x-iQAjXsMs1",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "## Calculating credible intervals\n",
@@ -777,7 +805,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -54,7 +54,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -52,11 +52,9 @@
     "tags": []
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -4,6 +4,10 @@
    "cell_type": "markdown",
    "id": "21d3b778-8402-4dbf-afa8-430d0f60bd70",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "source": [
@@ -84,31 +88,49 @@
    "cell_type": "markdown",
    "id": "33012497-9c29-4a93-9217-f47d05b6afa7",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "source": [
-    "##  Installation "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "2d4b9924-664f-49dd-a2b4-57e2f7cc4a78",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# -- Those packages will be needed for the execution\n",
-    "#! pip install -q lalsuite==7.25 pesummary==1.3.2"
+    "## Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "c639a964-3924-4e84-a799-7ff575e1da83",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "source": [
-    "**Important:** With Google Colab, you may need to restart the runtime after running the cell above."
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2d4b9924-664f-49dd-a2b4-57e2f7cc4a78",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# -- Those packages will be needed for the execution\n",
+    "#! pip install -q lalsuite==7.25 pesummary==1.3.2"
    ]
   },
   {
@@ -879,6 +901,10 @@
    "cell_type": "markdown",
    "id": "a81f257b-3515-4d79-b753-863508e374d4",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "source": [
@@ -914,7 +940,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e4739abf-59de-4b7e-b0d1-c6399daa7a4b",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": []
   }

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -111,7 +111,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.1_Parameter_estimation_for_compact_object_mergers_with_LALInference.ipynb
@@ -109,11 +109,9 @@
     "tags": []
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {
@@ -251,7 +249,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extracting all files from /var/folders/54/s302xgds5h9f58fhfjzj7nm80000gp/T/astropy-download-24567-2m37l2y9\n"
+      "Extracting all files from /var/folders/54/s302xgds5h9f58fhfjzj7nm80000gp/T/astropy-download-8242-4k2mqngt\n"
      ]
     },
     {

--- a/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
@@ -45,11 +45,9 @@
     "tags": []
    },
    "source": [
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell below.\n",
-    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
-    "</div>"
+    "> ⚠️ **Warning**: restart the runtime after running the cell below.\n",
+    ">\n",
+    "> To do so, click \"Runtime\" in the menu and choose \"Restart and run all\"."
    ]
   },
   {

--- a/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
@@ -47,7 +47,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "<div><b>⚠️Warning</b></div>\n",
-    "    Restart the runtime after running the cell above.\n",
+    "    Restart the runtime after running the cell below.\n",
     "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
     "</div>"
    ]

--- a/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
@@ -4,7 +4,12 @@
    "cell_type": "markdown",
    "metadata": {
     "Collapsed": "false",
-    "id": "quA5zQqJ3DkE"
+    "editable": true,
+    "id": "quA5zQqJ3DkE",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "<span style=\"float: left;padding: 1.3em\">![logo](../logo.png)</span>\n",
@@ -19,10 +24,32 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "d9Gqo4JLo1TK"
+    "editable": true,
+    "id": "d9Gqo4JLo1TK",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
-    "# Installation (execute only if running on a cloud platform!)"
+    "# Installation (execute only if running on a cloud platform, like Google Colab, or if you haven't done the installation already!)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<div><b>⚠️Warning</b></div>\n",
+    "    Restart the runtime after running the cell above.\n",
+    "    To do so, click \"Runtime\" in the menu and choose \"Restart and run all\".\n",
+    "</div>"
    ]
   },
   {
@@ -32,8 +59,12 @@
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "editable": true,
     "id": "IyoSoBizvTE0",
     "outputId": "6d2df641-3067-44fc-d31d-6cdc54569b90",
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "outputs": [],
@@ -597,7 +628,12 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "id": "AL7hSWYoskEQ"
+    "editable": true,
+    "id": "AL7hSWYoskEQ",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -724,7 +760,12 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "deCj6BiZ2Jvv"
+    "editable": true,
+    "id": "deCj6BiZ2Jvv",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "\n",


### PR DESCRIPTION
This PR addresses the recommendation to make warnings for Google Colab more visible as suggested in #33.

To do so, we add an info box (see below) in a dedicated section near the top of the notebook:

```html
<div class="alert alert-block alert-info">
<div><b>⚠️Warning</b></div>
    Restart the runtime after running the cell below.
    To do so, click "Runtime" in the menu and choose "Restart and run all".
</div>
```

Here are some details:
- We choose an info box (i.e. a blue background) and not a warning box (i.e. a yellow background); unfortunately, the background is not displayed on Colab.
- The instruction on how to restart the kernel are adapted to Colab.
- For some reasons, this led to modifications in notebooks' and cells' metadata.