### PR TITLE
Add additional info on PE sample release

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -11,6 +11,7 @@ https://lscsoft.docs.ligo.org/bilby/examples.html/n
 https://pycbc.org/pycbc/latest/html/noise.html/n
 https://raw.githubusercontent.com/gw-odw/odw/main/Tutorials/Day_3/toy_model.csv/n
 https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz/
+https://dcc.ligo.org/LIGO-P1800370/public/n
 
 # Some python cells use format string to forge URL.
 # The `{` (resp. `}`) there get translated to `%7B`(resp. `%7D`).

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -132,20 +132,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2025-03-06 16:09:23--  https://dcc.ligo.org/LIGO-P1800370/public/GW150914_GWTC-1.hdf5\n",
-      "131.215.125.133cc.ligo.org (dcc.ligo.org)… \n",
-      "connecté. à dcc.ligo.org (dcc.ligo.org)|131.215.125.133|:443… \n",
-      "requête HTTP transmise, en attente de la réponse… 302 Found\n",
-      "Emplacement : https://dcc.ligo.org/public/0157/P1800370/005/GW150914_GWTC-1.hdf5 [suivant]\n",
-      "--2025-03-06 16:09:24--  https://dcc.ligo.org/public/0157/P1800370/005/GW150914_GWTC-1.hdf5\n",
-      "Réutilisation de la connexion existante à dcc.ligo.org:443.\n",
-      "200 OKe HTTP transmise, en attente de la réponse… \n",
-      "Taille : 7026464 (6,7M)\n",
-      "Sauvegarde en : « GW150914_GWTC-1.hdf5 »\n",
+      "--2025-04-21 16:51:18--  https://dcc.ligo.org/LIGO-P1800370/public/GW150914_GWTC-1.hdf5\n",
+      "Resolving dcc.ligo.org (dcc.ligo.org)... 131.215.125.133\n",
+      "Connecting to dcc.ligo.org (dcc.ligo.org)|131.215.125.133|:443... connected.\n",
+      "HTTP request sent, awaiting response... 302 Found\n",
+      "Location: https://dcc.ligo.org/public/0157/P1800370/005/GW150914_GWTC-1.hdf5 [following]\n",
+      "--2025-04-21 16:51:19--  https://dcc.ligo.org/public/0157/P1800370/005/GW150914_GWTC-1.hdf5\n",
+      "Reusing existing connection to dcc.ligo.org:443.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 7026464 (6.7M)\n",
+      "Saving to: ‘GW150914_GWTC-1.hdf5’\n",
       "\n",
-      "GW150914_GWTC-1.hdf 100%[===================>]   6,70M  5,18MB/s    ds 1,3s    \n",
+      "GW150914_GWTC-1.hdf 100%[===================>]   6.70M  18.2MB/s    in 0.4s    \n",
       "\n",
-      "2025-03-06 16:09:25 (5,18 MB/s) — « GW150914_GWTC-1.hdf5 » sauvegardé [7026464/7026464]\n",
+      "2025-04-21 16:51:19 (18.2 MB/s) - ‘GW150914_GWTC-1.hdf5’ saved [7026464/7026464]\n",
       "\n"
      ]
     }
@@ -156,6 +156,7 @@
     "# if you do not have wget installed, simply download manually \n",
     "# https://dcc.ligo.org/LIGO-P1800370/public/GW150914_GWTC-1.hdf5 \n",
     "# from your browser\n",
+    "# Learn more about this dataset here: https://dcc.ligo.org/LIGO-P1800370/public\n",
     "! wget https://dcc.ligo.org/LIGO-P1800370/public/{label}_GWTC-1.hdf5"
    ]
   },


### PR DESCRIPTION
This adds a link to documentation related to the PE sample release downloaded in tutorial 3.3.