### PR TITLE
Reduce noisy output from wget

### DIFF
--- a/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
+++ b/Tutorials/Day_3/Tuto_3.1_Introduction_to_parameter_estimation.ipynb
@@ -106,7 +106,7 @@
     "import os\n",
     "if not os.path.isfile(\"toy_model.csv\"):\n",
     "  print(\"Downloading toy_model.csv\")\n",
-    "  ! wget https://raw.githubusercontent.com/gw-odw/odw/main/Tutorials/Day_3/toy_model.csv\n",
+    "  ! wget --no-verbose https://raw.githubusercontent.com/gw-odw/odw/main/Tutorials/Day_3/toy_model.csv\n",
     "else:\n",
     "  print(\"toy_model.csv exists; not downloading\")"
    ]

--- a/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
+++ b/Tutorials/Day_3/Tuto_3.3_Discovering_and_using_published_posterior_samples.ipynb
@@ -132,21 +132,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2025-04-21 16:51:18--  https://dcc.ligo.org/LIGO-P1800370/public/GW150914_GWTC-1.hdf5\n",
-      "Resolving dcc.ligo.org (dcc.ligo.org)... 131.215.125.133\n",
-      "Connecting to dcc.ligo.org (dcc.ligo.org)|131.215.125.133|:443... connected.\n",
-      "HTTP request sent, awaiting response... 302 Found\n",
-      "Location: https://dcc.ligo.org/public/0157/P1800370/005/GW150914_GWTC-1.hdf5 [following]\n",
-      "--2025-04-21 16:51:19--  https://dcc.ligo.org/public/0157/P1800370/005/GW150914_GWTC-1.hdf5\n",
-      "Reusing existing connection to dcc.ligo.org:443.\n",
-      "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: 7026464 (6.7M)\n",
-      "Saving to: ‘GW150914_GWTC-1.hdf5’\n",
-      "\n",
-      "GW150914_GWTC-1.hdf 100%[===================>]   6.70M  18.2MB/s    in 0.4s    \n",
-      "\n",
-      "2025-04-21 16:51:19 (18.2 MB/s) - ‘GW150914_GWTC-1.hdf5’ saved [7026464/7026464]\n",
-      "\n"
+      "2025-05-05 23:19:59 URL:https://dcc.ligo.org/public/0157/P1800370/005/GW150914_GWTC-1.hdf5 [7026464/7026464] -> \"GW150914_GWTC-1.hdf5\" [1]\n"
      ]
     }
    ],
@@ -157,7 +143,7 @@
     "# https://dcc.ligo.org/LIGO-P1800370/public/GW150914_GWTC-1.hdf5 \n",
     "# from your browser\n",
     "# Learn more about this dataset here: https://dcc.ligo.org/LIGO-P1800370/public\n",
-    "! wget https://dcc.ligo.org/LIGO-P1800370/public/{label}_GWTC-1.hdf5"
+    "! wget --no-verbose https://dcc.ligo.org/LIGO-P1800370/public/{label}_GWTC-1.hdf5"
    ]
   },
   {

--- a/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
+++ b/Tutorials/Extension_topics/Tuto_A.2_Population_Inference_with_GWPopulation.ipynb
@@ -198,17 +198,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2025-02-22 14:50:25--  https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz\n",
-      "Résolution de dcc.ligo.org (dcc.ligo.org)… 131.215.125.133\n",
-      "connecté. à dcc.ligo.org (dcc.ligo.org)|131.215.125.133|:443… \n",
-      "requête HTTP transmise, en attente de la réponse… 200 OK\n",
-      "Taille : 106436912 (102M) [application/x-gzip]\n",
-      "Sauvegarde en : « ./tuto_A.2/downsampled.tar.gz »\n",
-      "\n",
-      "./tuto_A.2/downsamp 100%[===================>] 101,51M  3,33MB/s    ds 26s     \n",
-      "\n",
-      "2025-02-22 14:50:52 (3,85 MB/s) — « ./tuto_A.2/downsampled.tar.gz » sauvegardé [106436912/106436912]\n",
-      "\n",
+      "2025-05-05 20:45:24 URL:https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz [106436912/106436912] -> \"./tuto_A.2/downsampled.tar.gz\" [1]\n",
       "x ./S191103a.h5\n",
       "x ./S191105e.h5\n",
       "x ./S191109d.h5\n",
@@ -239,7 +229,7 @@
    ],
    "source": [
     "!mkdir tuto_A.2\n",
-    "!wget -O ./tuto_A.2/downsampled.tar.gz \"https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz\"\n",
+    "!wget --no-verbose -O ./tuto_A.2/downsampled.tar.gz \"https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz\"\n",
     "!tar -xvzf ./tuto_A.2/downsampled.tar.gz -C ./tuto_A.2\n",
     "import glob\n",
     "files = glob.glob('./tuto_A.2/*.h5')"


### PR DESCRIPTION
This PR addresses #59 by reducing the verbosity of call to `wget`.

Note that there is no big change in tutorial 3.1 because the file is already present (it's in the repository) so `wget` is not executed.