### PR TITLE
Use lychee preprocess to simplify .lycheeignore

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,17 +16,28 @@ concurrency:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Installing requirements
+        run: |
+          pip install -r requirements.txt
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
+          lycheeVersion: "latest"
           args: |
             --no-progress
             --include-fragments
             -E
             --require-https
+            --preprocess "./tests/lychee_preprocess.sh"
             './**/*.ipynb' './**/*.md'
 
       - name: Provide helpful failure message

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          lycheeVersion: "latest"
+          lycheeVersion: "v0.22.0"
           args: |
             --no-progress
             --include-fragments

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,23 +1,8 @@
-# Issues with links in Jupyter Notebook files.
-# Remove once https://github.com/lycheeverse/lychee/issues/1659 is resolved.
-https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz/n
-https://dcc.ligo.org/public/0157/P1800370/005/GW150914_GWTC-1.hdf5/n
-https://raw.githubusercontent.com/gw-odw/odw/main/Tutorials/Day_3/toy_model.csv/n
-https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T2_1.gwf/n
-https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T2_2.gwf/n
-https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T2_0.gwf/n
-https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/Data/PyCBC_T3_0.gwf/n
-https://lscsoft.docs.ligo.org/bilby/examples.html/n
-https://pycbc.org/pycbc/latest/html/noise.html/n
-https://raw.githubusercontent.com/gw-odw/odw/main/Tutorials/Day_3/toy_model.csv/n
-https://dcc.ligo.org/public/0182/T2200137/001/O3bPE_downsampled.tar.gz/
-https://dcc.ligo.org/LIGO-P1800370/public/n
-
 # Some python cells use format string to forge URL.
 # The `{` (resp. `}`) there get translated to `%7B`(resp. `%7D`).
 # This is hard to fix with lychee since it can't understand placeholders.
 # So this is another valid exclude.
-https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/%7B%7D/
+https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/%7B%7D
 https://dcc.ligo.org/LIGO-P1800370/public/%7Blabel%7D_GWTC-1.hdf5
 
 # Exclude all file-links. Workaround until https://github.com/lycheeverse/lychee/issues/1646 is resolved

--- a/tests/lychee_preprocess.sh
+++ b/tests/lychee_preprocess.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# This is a preprocess script for lychee (see https://github.com/gw-odw/odw/issues/72)
+# We convert jupyter notebooks to markdown to ease extraction of links
+# Other files are left unchanged
+
+case "$1" in
+    *.ipynb)
+        exec jupyter nbconvert --to markdown --stdout "$1"
+        ;;
+    *)
+        # identity function, output input without changes
+        exec cat
+        ;;
+esac


### PR DESCRIPTION
This PR tackles #72.

We add a preprocess script for lychee in order to have more robust link extraction and less patterns in `.lycheeignore`.

As we only check links in notebooks and Markdown files, we only need to care about those formats:

- Markdown is natively understood by lychee so we have nothing to do.
- For notebooks, we convert to Markdown with `jupyter nbconvert`.

The script is in file `tests/lychee_preprocess.sh`.

With this, we can remove some patterns introduces in #21. For some reasons, we need to change `https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/%7B%7D/` to `https://github.com/gw-odw/odw/raw/main/Tutorials/Day_2/%7B%7D`.

We also update the CI action for links (`links.yml`). Currently [lychee-action](https://github.com/lycheeverse/lychee-action/releases/tag/v2.7.0) uses `lychee v0.21.0` by default so we must use `lycheeVersion: "v0.22.0"` (which is good).

There is a drawback though: the preprocess script must now have access to `jupyter` and therefore we must install it; we couldn't use `conda` like in other actions because `lychee-action` ignores it; we install it through `pip`; this makes the CI action slower.
 
Closes #72.