### PR TITLE
Test latest lychee-action

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          lycheeVersion: "v0.22.0"
           args: |
             --no-progress
             --include-fragments


### PR DESCRIPTION
Following request lycheeverse/lychee-action#327, lychee-action now uses lychee v0.22.0 by default. As a courtesy, we are testing this version, although we will likely keep the explicit version.