### PR TITLE
Use pip instead of conda in CI

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,13 +26,14 @@ jobs:
     - run: |
         echo "Testing Day ${{ matrix.day }} Tutorials on python ${{ matrix.python-version }}"
     - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
     - name: Installing requirements
       run: |
-        conda env create -f environment.yml
+        pip install -r requirements.txt
     - name: Test notebooks execution
       run: |
-        conda activate odw-py311
         for file in Tutorials/Day_${{ matrix.day }}/*ipynb; do
             echo "Checking ${file}";
             if ! ./tests/check_run.sh "${file}"; then

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -25,13 +25,14 @@ jobs:
     - run: |
         echo "Spellchecking Day ${{ matrix.day }} Tutorials on python ${{ matrix.python-version }}"
     - uses: actions/checkout@v4
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
     - name: Installing requirements
       run: |
-        conda env create -f environment.yml
+        pip install -r requirements.txt
     - name: Spellchecking notebooks
       run: |
-        conda activate odw-py311
         for file in Tutorials/Day_${{ matrix.day }}/*ipynb; do
             echo "Checking ${file}";
             if ! ./tests/check_spelling.sh "${file}"; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ pygcn==1.0.2
 pesummary==1.3.2
 gwpopulation==0.10.0
 nestle==0.2.0
+# Development dependencies
+codespell==2.3.0


### PR DESCRIPTION
This PR modifies CI actions to install prerequisite with pip instead of conda (inspired by what was done in #73 to install `jupyter`): this slightly speed-up things (although for some actions this is a small part of the run time). We just need to add `codespell` in `requirements.txt`.