### PR TITLE
Use python 3.12 in CI

### DIFF
--- a/.github/workflows/execution_order.yml
+++ b/.github/workflows/execution_order.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
         topic: ["01_Accessing_Open_Data", "02_Generating_Waveforms", "03_Signal_Processing", "04_Searches", "05_Parameter_Estimation"]
 
     steps:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Installing requirements
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
         topic: ["01_Accessing_Open_Data", "02_Generating_Waveforms", "03_Signal_Processing", "04_Searches", "05_Parameter_Estimation"]
 
     steps:
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Installing requirements
       run: |
         pip install -r requirements.txt

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -18,7 +18,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
         topic: ["01_Accessing_Open_Data", "02_Generating_Waveforms", "03_Signal_Processing", "04_Searches", "05_Parameter_Estimation"]
 
     steps:
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Installing requirements
       run: |
         pip install -r requirements.txt
@@ -49,7 +49,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
 
     steps:
     - run: |

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
         topic: ["01_Accessing_Open_Data", "02_Generating_Waveforms", "03_Signal_Processing", "04_Searches", "05_Parameter_Estimation"]
 
     steps:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
 
     steps:
     - run: |

--- a/setup.md
+++ b/setup.md
@@ -7,7 +7,7 @@ If you are not familiar with Jupyter notebooks, google one of the many introduct
 
 The various options are listed in order of difficulty. However, whenever possible, we recommend the participants with some experience with Python environments to follow [Option 3](#option3), installing the requirements on their laptops and executing the tutorial notebooks from there. This has the advantage of avoiding any possible issue with online servers, including unstable internet connection or uneven memory and server availability, both on Colab and on MyBinder.
 
-This workshop uses [Python version 3.11](https://www.python.org/downloads/release/python-3110/).
+This workshop uses [Python version 3.12](https://www.python.org/downloads/release/python-3120/).
 
 ## Option 1: Google Colab
 


### PR DESCRIPTION
As pointed in https://github.com/gw-odw/odw/issues/77#issuecomment-4217851458, CI still uses python 3.11 instead of 3.12. This PR updates this.