### PR TITLE
removed note about O2_16KHZ_R1 and added note about O4b1Disc

### DIFF
--- a/Tutorials/01_Accessing_Open_Data/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/01_Accessing_Open_Data/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Attention: Observing runs whose names end with \"Disc\" are not real runs but only structures we add in our database for technical reasons and are associated with events published before the data release of the associated observing run (e.g. O4b1Disc -> GW241011)_"
+    "_Attention: Observing runs whose names end with \"Disc\" are not real runs but only structures we add in our database for technical reasons and are associated with GW candidate detections published before the data release of the associated observing run. The papers about these detections are called in our jargon \"discovery papers\", hence the \"Disc\" suffix (e.g. O4b1Disc -> GW241011)_"
    ]
   },
   {
@@ -564,6 +564,13 @@
     "- How many GWTC-3-confident events were detected during O3b?\n",
     "- How many events have been detected with a network signal to noise ratio (SNR) >= 30? "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/Tutorials/01_Accessing_Open_Data/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/01_Accessing_Open_Data/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Attention: Observing runs whose names end with \"Disc\" are not real runs but only structures we add in our database for tecnical reasons and are associated with events published before the data release of the associated observing run (e.g. O4b1Disc -> GW241011)_"
+    "_Attention: Observing runs whose names end with \"Disc\" are not real runs but only structures we add in our database for technical reasons and are associated with events published before the data release of the associated observing run (e.g. O4b1Disc -> GW241011)_"
    ]
   },
   {

--- a/Tutorials/01_Accessing_Open_Data/Tuto_1.1_Discovering_Open_Data.ipynb
+++ b/Tutorials/01_Accessing_Open_Data/Tuto_1.1_Discovering_Open_Data.ipynb
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Attention: Note that the most recent observation runs, e.g. O2, are labeled with names containing the name of the run (e.g. O2), the sampling rate (4 or 16 kHz) and the release version (e.g. R1). This means that for O2 you have two labels 'O2_4KHZ_R1' and 'O2_16KHZ_R1', depending which is the desired sampling rate_"
+    "_Attention: Observing runs whose names end with \"Disc\" are not real runs but only structures we add in our database for tecnical reasons and are associated with events published before the data release of the associated observing run (e.g. O4b1Disc -> GW241011)_"
    ]
   },
   {
@@ -560,17 +560,10 @@
     "\n",
     "Now that you've seen examples of how to query for dataset information using the `gwosc` package, please try and complete the following exercises using that interface:\n",
     "\n",
-    "- How many months did O2 last? (Hint: check the output of _find_datasets(type='run')_ to find the correct label to use)\n",
+    "- How many months did O2 last?\n",
     "- How many GWTC-3-confident events were detected during O3b?\n",
     "- How many events have been detected with a network signal to noise ratio (SNR) >= 30? "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Because of the new structure of our database, the output of `find_datasets(type='run')` now gives the name of the actual run and not of the tiledatasets, which have names like O2_4KHZ_R1. The tutorial had a note about that and a comment also in one of the questions, both removed.

In addition,  `find_datasets(type='run')` now gives as output also the fake runs we build when preparing the special events released before the run, so I added a note also about this.