### PR TITLE
updated tutorials to show the correct tutorial number on colab

### DIFF
--- a/Tutorials/01_Accessing_Open_Data/Tuto_1.2_Accessing_Open_Data_with_GWpy_PyCBC.ipynb
+++ b/Tutorials/01_Accessing_Open_Data/Tuto_1.2_Accessing_Open_Data_with_GWpy_PyCBC.ipynb
@@ -648,7 +648,7 @@
  ],
  "metadata": {
   "colab": {
-   "name": "Tuto 1.2 Open Data access with GWpy.ipynb",
+   "name": "Tuto 1.2 Accessing Open Data with GWpy and PyCBC.ipynb",
    "provenance": []
   },
   "kernelspec": {

--- a/Tutorials/02_Generating_Waveforms/Extracurricular_topics.ipynb
+++ b/Tutorials/02_Generating_Waveforms/Extracurricular_topics.ipynb
@@ -601,7 +601,7 @@
  ],
  "metadata": {
   "colab": {
-   "name": "Tuto 1.4 Generating waveforms.ipynb",
+   "name": "Extracurricular topics.ipynb",
    "provenance": []
   },
   "kernelspec": {

--- a/Tutorials/02_Generating_Waveforms/Tuto_2.1_Generating_waveforms.ipynb
+++ b/Tutorials/02_Generating_Waveforms/Tuto_2.1_Generating_waveforms.ipynb
@@ -627,7 +627,7 @@
  ],
  "metadata": {
   "colab": {
-   "name": "Tuto 1.4 Generating waveforms.ipynb",
+   "name": "Tuto 2.1 Generating waveforms.ipynb",
    "provenance": []
   },
   "kernelspec": {

--- a/Tutorials/03_Signal_Processing/Tuto_3.2_Noise_PSD.ipynb
+++ b/Tutorials/03_Signal_Processing/Tuto_3.2_Noise_PSD.ipynb
@@ -1504,7 +1504,7 @@
  ],
  "metadata": {
   "colab": {
-   "name": "Tuto 1.2 Open Data access with GWpy.ipynb",
+   "name": "Tutorial 3.2: Estimating the noise PSD and whitening/band-passing data.ipynb",
    "provenance": []
   },
   "kernelspec": {

--- a/Tutorials/04_Searches/Tuto_4.1_Matched_filtering_introduction.ipynb
+++ b/Tutorials/04_Searches/Tuto_4.1_Matched_filtering_introduction.ipynb
@@ -549,7 +549,7 @@
  ],
  "metadata": {
   "colab": {
-   "name": "Tuto_2.1_Matched_filtering_introduction.ipynb",
+   "name": "Tuto_4.1_Matched_filtering_introduction.ipynb",
    "provenance": []
   },
   "kernelspec": {

--- a/Tutorials/04_Searches/Tuto_4.2_Matched_Filtering_in_Action.ipynb
+++ b/Tutorials/04_Searches/Tuto_4.2_Matched_Filtering_in_Action.ipynb
@@ -728,7 +728,7 @@
  ],
  "metadata": {
   "colab": {
-   "name": "Tuto_2.2_Matched_Filtering_In_action.ipynb",
+   "name": "Tuto_4.2_Matched_Filtering_In_action.ipynb",
    "provenance": []
   },
   "kernelspec": {

--- a/Tutorials/04_Searches/Tuto_4.3_Signal_consistency_and_significance.ipynb
+++ b/Tutorials/04_Searches/Tuto_4.3_Signal_consistency_and_significance.ipynb
@@ -817,7 +817,7 @@
    "lastKernelId": null
   },
   "colab": {
-   "name": "Tuto_2.3_Signal_consistency_and_significance.ipynb",
+   "name": "Tuto_4.3_Signal_consistency_and_significance.ipynb",
    "provenance": []
   },
   "kernelspec": {

--- a/Tutorials/05_Parameter_Estimation/Tuto_5.2_Parameter_estimation_for_compact_object_mergers.ipynb
+++ b/Tutorials/05_Parameter_Estimation/Tuto_5.2_Parameter_estimation_for_compact_object_mergers.ipynb
@@ -1463,7 +1463,7 @@
  ],
  "metadata": {
   "colab": {
-   "name": "Tuto_3.2_Parameter_estimation_for_compact_object_mergers.ipynb",
+   "name": "Tuto_5.2_Parameter_estimation_for_compact_object_mergers.ipynb",
    "provenance": []
   },
   "kernelspec": {


### PR DESCRIPTION
On google colab a title of the tutorials appear and it depends on metadata  inside the notebooks. I have updated the metadata in the notebooks  to match at least the tutorial number